### PR TITLE
Revert "Use yarn if available"

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,14 +3,8 @@ pushd %~dp0
 setlocal
 
 :Build
-
-:: https://stackoverflow.com/a/27014081 answering https://stackoverflow.com/questions/10686737/check-whether-command-is-available-in-batch-file/27014081#27014081
-call where yarn >nul 2>nul
-if %ERRORLEVEL% == 1 (
-  call npm install
-) else (
-  call yarn install
-)
+call npm install
+if %ERRORLEVEL% neq 0 goto BuildFail
 
 call npm run validate
 if %ERRORLEVEL% neq 0 goto BuildFail


### PR DESCRIPTION
This reverts commit 5853117a214b93b6c54c42734362a563e2ff6575.

Since `npm-shrinkwrap.json` is used do not use yarn.